### PR TITLE
veyron-speedy also does not support discard on F2FS

### DIFF
--- a/fs/install-to-emmc-begin
+++ b/fs/install-to-emmc-begin
@@ -87,11 +87,11 @@ partx -a ${MMCDEV} 2>/dev/null || true
 sleep 1
 
 echo "Installing to $ROOTPART"
-# f2fs time boiii
-if [ "$TARGET" = "kevin" -o "$TARGET" = "lazor" ]; then
+# Models which don't support discard on f2fs
+if [ "$TARGET" = "kevin" -o "$TARGET" = "lazor" -o "$TARGET" = "speedy" ]; then
 	case "$FILESYSTEM" in
 		f2fs)
-			mkfs.f2fs -f $ROOTPART -t 0 # kevin and lazor don't support discard on f2fs?
+			mkfs.f2fs -f $ROOTPART -t 0
 		;;
 		ext4)
 			mkfs.ext4 -F $ROOTPART


### PR DESCRIPTION
Encountered this one on ASUS C201 and spent a a bit of time trying to figure out why mkfs.f2fs was failing before I realized other models were affected and had mitigations in place.

------

Also, thank you for publishing this. I had wanted to try out panfrost for a while but remembered how finicky and tedious it was to get a distro installed to the eMMC.