### PR TITLE
Docker image with reproducible build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# FROM ubuntu:20.04
+FROM debian:10
+
+ARG DEBIAN_FRONTEND=noninteractive
+# RUN sed -i "s/# deb-src/deb-src/g" /etc/apt/sources.list
+RUN echo "deb-src http://deb.debian.org/debian buster main" >> /etc/apt/sources.list \
+    && echo "deb-src http://deb.debian.org/debian buster-updates main" >> /etc/apt/sources.list \
+    && echo "deb-src http://security.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list
+
+RUN apt-get update \
+    && apt-get build-dep -y linux \
+    && apt-get install -y libarchive-tools curl wget f2fs-tools cgpt vboot-utils libncurses-dev gawk flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf qemu-user-static gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu parted udev git debootstrap u-boot-tools qemu-user lz4
+
+# Newer version of qemu-aarch64-static is needed as it fixes a bug causing a segfault
+RUN wget http://security.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_5.2+dfsg-9ubuntu3.1_amd64.deb \
+    && dpkg -i qemu-user-static_5.2+dfsg-9ubuntu3.1_amd64.deb \
+    && rm qemu-user-static_5.2+dfsg-9ubuntu3.1_amd64.deb
+
+# arch-test causes debootstrap to fail. Remove
+RUN apt-get remove -y arch-test
+    # && update-binfmts --enable \
+    # && service binfmt-support restart
+

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Once you have this out, continue with instructions:
 #### *Binary drivers are unsupported in Cadmium and never will be*
 
 ## Dependencies on build machine
+### Docker Method
+`Dockerfile` defines a build environment containing all the dependencies needed. The docker image can be build with `docker build . -t cadmium_build`. After this, it can be run as follows
+```
+user@hostname:~/Cadmium$ docker run --rm -it --privileged -v /dev:/dev -v $(pwd):/code cadmium bash
+root@3519cde987d5:/# update-binfmts --enable
+root@3519cde987d5:/# 
+```
+The docker container has to be run with `--privileged` and `-v /dev:/dev` as this is needed for mounting loopback devices and running debootstrap/chroot. Inside the docker shell, `update-binfmts --enable` has to be run once, after which the environment is ready for building Cadmium images.
+
+### Non-Docker Method
 - Recent Linux distribution
 - Binfmt when Debian rootfs is used
 - ```debootstrap``` when Debian rootfs is used


### PR DESCRIPTION
Since there are quite a lot of dependencies needed to build cadmium, I've made a docker image that incorporates in everything needed. This will be especially useful for new users who want to build and test this out. 

All that is needed to run a container with this image is to have docker installed, build/pull a prebuilt image, launch a container with the appropriate flags (`--privileged -v /dev:/dev`) and run the `update-binfmts --enable` command within the container. The container should be ready to build. Tested this out on a fresh ubuntu server 20.04 VM and nothing other than docker is needed on the host.

I've also uploaded a pre-built image [here](https://github.com/users/Genius1237/packages/container/package/cadmium), in case anyone wants to test out.