### PR TITLE
Fix sed spelling error

### DIFF
--- a/ui/sway/mkconfig
+++ b/ui/sway/mkconfig
@@ -26,7 +26,7 @@ sed -i'' "s#PLACEHOLDER_BAT#$BAT#g" /mnt/etc/sway/config
 while true; do
     read -p "The default sway modkey is the search button, would you like to change it to alt1 (left alt key)? Please type yes or no: " yn
     case $yn in
-        [Yy]* ) sed -i'' "s#Mod4#Mod1#g" /mnt/etc/sway/config; break;;
+        [Yy]* ) sed -i'' "s#Mod4#Mod1#g" /mnt/etc/sway/config;;
         [Nn]* ) exit;;
         * ) echo "Please answer yes or no.";;
     esac


### PR DESCRIPTION
sed not being executed correctly makes it so the sway config does not get implemented correctly, making the script fail