### PR TITLE
add maybe missing systemctl enable for qrtr-ns

### DIFF
--- a/fs/postbuild
+++ b/fs/postbuild
@@ -44,6 +44,7 @@ chroot $CADMIUMROOT/tmp/root/ make -C /CdFiles/rmtfs clean
 chroot $CADMIUMROOT/tmp/root/ make -C /CdFiles/qmic prefix=/usr install
 chroot $CADMIUMROOT/tmp/root/ make -C /CdFiles/qrtr prefix=/usr install
 chroot $CADMIUMROOT/tmp/root/ make -C /CdFiles/rmtfs prefix=/usr install
+chroot $CADMIUMROOT/tmp/root/ systemctl enable qrtr-ns
 chroot $CADMIUMROOT/tmp/root/ systemctl enable rmtfs
 
 export CHRT="chroot $CADMIUMROOT/tmp/root"


### PR DESCRIPTION
just ran across this while borrowing the rmtfs setup from cadmium:
can it be that the qrtr-ns service needs to get enabled here as well?