### PR TITLE
debootstrap script fixes

### DIFF
--- a/fs/debian/build
+++ b/fs/debian/build
@@ -16,7 +16,7 @@ if [[ "$device_arch" != "armv7a" ]] || [[ "$device_arch" != "aarch64" ]]; then
 fi
 
 # debootstrap randomly just fails for no reason, but system turns out fine
-debootstrap --arch=$ARCH_DEB $SUITE $DESTDIR http://deb.debian.org/debian/
+debootstrap --arch=$ARCH_DEB $SUITE $DESTDIR https://deb.debian.org/debian/
 
 chroot $DESTDIR apt update
 chroot $DESTDIR apt install -y vim network-manager debootstrap parted f2fs-tools libudev-dev build-essential git firmware-ath9k-htc kmscube weston

--- a/fs/debian/build
+++ b/fs/debian/build
@@ -2,13 +2,21 @@
 set -x
 set -e
 
+device_arch=$(uname -m)
+
 CADMIUMROOT=$(dirname $(dirname $(dirname $(realpath $0))))
 DESTDIR=$1
 
 . $CADMIUMROOT/config
 
+# Ensure debootstrap has qemu-static bin before debootstrapping if it needs it
+if [[ "$device_arch" != "armv7a" ]] || [[ "$device_arch" != "aarch64" ]]; then
+	mkdir -p $DESTDIR/usr/bin
+	cp /usr/bin/qemu-arm-static $DESTDIR/usr/bin
+fi
+
 # debootstrap randomly just fails for no reason, but system turns out fine
-debootstrap --arch=$ARCH_DEB $SUITE $DESTDIR https://deb.debian.org/debian/
+debootstrap --arch=$ARCH_DEB $SUITE $DESTDIR http://deb.debian.org/debian/
 
 chroot $DESTDIR apt update
 chroot $DESTDIR apt install -y vim network-manager debootstrap parted f2fs-tools libudev-dev build-essential git firmware-ath9k-htc kmscube weston

--- a/fs/ubuntu/build
+++ b/fs/ubuntu/build
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -x
+set -e
+
+device_arch=$(uname -m)
+
+CADMIUMROOT=$(dirname $(dirname $(dirname $(realpath $0))))
+DESTDIR=$1
+
+. $CADMIUMROOT/config
+
+# Ensure debootstrap has qemu-static bin before debootstrapping if it needs it
+if [[ "$device_arch" != "armv7a" ]] || [[ "$device_arch" != "aarch64" ]]; then
+	mkdir -p $DESTDIR/usr/bin
+	cp /usr/bin/qemu-arm-static $DESTDIR/usr/bin
+fi
+
+# debootstrap randomly just fails for no reason, but system turns out fine
+debootstrap --arch=$ARCH_DEB $SUITE $DESTDIR http://ports.ubuntu.com/ 
+
+chroot $DESTDIR apt update
+chroot $DESTDIR apt install -y vim network-manager debootstrap parted f2fs-tools libudev-dev build-essential git firmware-ath9k-htc kmscube weston

--- a/fs/ubuntu/build
+++ b/fs/ubuntu/build
@@ -16,7 +16,9 @@ if [[ "$device_arch" != "armv7a" ]] || [[ "$device_arch" != "aarch64" ]]; then
 fi
 
 # debootstrap randomly just fails for no reason, but system turns out fine
-debootstrap --arch=$ARCH_DEB $SUITE $DESTDIR http://ports.ubuntu.com/ 
+debootstrap --arch=$ARCH_DEB $SUITE $DESTDIR http://ports.ubuntu.com/
+
+echo "deb http://ports.ubuntu.com/ $SUITE main universe multiverse" | sudo tee $DESTDIR/etc/apt/sources.list
 
 chroot $DESTDIR apt update
 chroot $DESTDIR apt install -y vim network-manager debootstrap parted f2fs-tools libudev-dev build-essential git firmware-ath9k-htc kmscube weston


### PR DESCRIPTION
The debootstrap phase will fail on x86_64 devices if qemu-arm-static isn't present in the new filesystem. A simple if condition fixes that.