### PR TITLE
README.md: Duet/kukui supports bluetooth

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Thanks @LoganMD for the logo
 | 3D Acceleration	  	| Y		    	| Y			| Y				| Y(FW)			| ?			| Y (FW)		|
 | GPU reclocking		| Y			| Y			| ?				| Y			| ?			| Y			|
 | Audio		     		| Y			| Y			| Y				| P(only usb + bt)	| Y			| P(only usb + bt)	|
-| Bluetooth		 	| N		    	| ?			| N				| Y			| Y			| Y			|
+| Bluetooth		 	| Y		    	| ?			| N				| Y			| Y			| Y			|
 | Front Camera			| N			| Y			| Y				| Y			| ?			| N			|
 | Back Camera		    	| N		    	|		 	| 				|			| ?			| N			|
 | USB				| Y		    	| Y			| Y				| Y			| Y			| Y			|


### PR DESCRIPTION
Bluetooth support was added to Duet/kukui in #81 so the README should be updated accordingly.

Signed-off-by: Hilmar Magnusson <hilmar.magnusson@bisdn.de>