### PR TITLE
Move DESTDIR above BOOTFW_INST_PKGS which uses it

### DIFF
--- a/fs/install
+++ b/fs/install
@@ -152,7 +152,7 @@ if [ "$BASEBOARD" = "trogdor" ]; then
 	chroot $DESTDIR systemctl enable rmtfs
 fi
 
-chroot $DESTDIR $FS_INST_PKGS $BOOTFW_PKGS
+chroot $DESTDIR $FS_INST_PKG $BOOTFW_PKGS
 
 if [ "$FS_HAS_OOBE" = "false" ]; then
 	echo "Enter root password:"

--- a/fs/install
+++ b/fs/install
@@ -71,7 +71,7 @@ BOOTFW=unknown
 if cat /proc/cmdline | grep -s cros_secure >/dev/null 2>&1; then
 	$FS_INST_PKG $FS_PKGS_CD_BOOTFW_DEPTHCHARGE
 	BOOTFW=depthcharge
-	BOOTFW_INST_PKGS="chroot $DESTDIR $FS_INST_PKG $FS_PKGS_CD_BOOTFW_DEPTHCHARGE"
+	BOOTFW_PKGS=$FS_PKGS_CD_BOOTFW_DEPTHCHARGE
 fi
 
 if [ "$BOOTFW" = "unknown" ]; then
@@ -152,7 +152,7 @@ if [ "$BASEBOARD" = "trogdor" ]; then
 	chroot $DESTDIR systemctl enable rmtfs
 fi
 
-$BOOTFW_INST_PKGS
+chroot $DESTDIR $FS_INST_PKGS $BOOTFW_PKGS
 
 if [ "$FS_HAS_OOBE" = "false" ]; then
 	echo "Enter root password:"

--- a/fs/install
+++ b/fs/install
@@ -71,7 +71,7 @@ BOOTFW=unknown
 if cat /proc/cmdline | grep -s cros_secure >/dev/null 2>&1; then
 	$FS_INST_PKG $FS_PKGS_CD_BOOTFW_DEPTHCHARGE
 	BOOTFW=depthcharge
-	BOOTFW_PKGS=$FS_PKGS_CD_BOOTFW_DEPTHCHARGE
+	BOOTFW_PKGS="$FS_PKGS_CD_BOOTFW_DEPTHCHARGE"
 fi
 
 if [ "$BOOTFW" = "unknown" ]; then


### PR DESCRIPTION
As-is installation fails when BOOTFW_INST_PKGS is called. 
This small change fixes that. 
I was able to get this commit running on my chromebook-kevin